### PR TITLE
feat: modify the format of the thinning output so that it's compatible with cross-cutting in post-processing

### DIFF
--- a/forestryfunctions/harvest/thinning.py
+++ b/forestryfunctions/harvest/thinning.py
@@ -23,33 +23,38 @@ def iterative_thinning(
     n = len(stand.reference_trees)
     c = thinning_factor
     # stems_removed = 0.0
-    thinning_output = {}
+
+    #initialises the thinning_output dictionary where stems_removed_per_ha is aggregated to during the thinning operation
+    thinning_output = {
+        rt.identifier: 
+            {
+                'stems_removed_per_ha': 0.0,
+                'species': rt.species,
+                'breast_height_diameter': rt.breast_height_diameter,
+                'height': rt.height,
+                'stems_per_ha': rt.stems_per_ha,
+                'stand_area': stand.area,
+            } 
+            for rt in stand.reference_trees
+        }
+
     while thin_predicate(stand):
         # cut until lower bound reached
         for i, rt in enumerate(stand.reference_trees):
             thin_factor = c + extra_factor_solver(i, n, c)
             thin_factor = 1.0 if thin_factor > 1.0 else thin_factor
             new_stems_per_ha = rt.stems_per_ha * thin_factor
-            # stems_removed += rt.stems_per_ha - new_stems_per_ha
-            stems_removed_per_ha = rt.stems_per_ha - new_stems_per_ha
+            thinning_output[rt.identifier]["stems_removed_per_ha"] += rt.stems_per_ha - new_stems_per_ha
             rt.stems_per_ha = new_stems_per_ha
 
-            # collect stems_removed and tree-level variables required by the cross cut function per reference tree to dict.
-            # this structure is currently stored in operation_aggregates separately for each thinning method and for each timing.
+            
             
             #NOTE: some considerations to address before merging
             # 1. Will collecting this data on per-reference_tree basis be a memory issue when running the sim with a full dataset?
             # 2. I'd also rather make thinning_output a class imported from the forest-data-model library.
             # 3. I'm currently assuming that since the new_aggregate is written per thinning_method and per time_point, 
             #  the thinning_output will not be written to twice (otherwise would need to accommodate it for updates)
-            thinning_output[rt.identifier] = {
-                'stems_removed_per_ha': stems_removed_per_ha,
-                'species': rt.species,
-                'breast_height_diameter': rt.breast_height_diameter,
-                'height': rt.height,
-                'stems_per_ha': rt.stems_per_ha,
-                'stand_area': stand.area,
-            }
-            
+    
+    # this structure is currently stored in operation_aggregates separately for each thinning method and for each timing.
     new_aggregate = {'thinning_output': thinning_output}
     return (stand, new_aggregate)

--- a/forestryfunctions/harvest/thinning.py
+++ b/forestryfunctions/harvest/thinning.py
@@ -6,7 +6,7 @@ def iterative_thinning(
         stand: ForestStand,
         thinning_factor: float,
         thin_predicate: Callable,
-        extra_factor_solver: Callable,
+        extra_factor_solver: Callable
 ) -> Tuple[ForestStand, dict]:
     """ Iteratively decreases the stem count of stand reference trees until stoppin condition is met.
 
@@ -22,7 +22,6 @@ def iterative_thinning(
     """
     n = len(stand.reference_trees)
     c = thinning_factor
-    # stems_removed = 0.0
 
     #initialises the thinning_output dictionary where stems_removed_per_ha is aggregated to during the thinning operation
     thinning_output = {
@@ -47,14 +46,5 @@ def iterative_thinning(
             thinning_output[rt.identifier]["stems_removed_per_ha"] += rt.stems_per_ha - new_stems_per_ha
             rt.stems_per_ha = new_stems_per_ha
 
-            
-            
-            #NOTE: some considerations to address before merging
-            # 1. Will collecting this data on per-reference_tree basis be a memory issue when running the sim with a full dataset?
-            # 2. I'd also rather make thinning_output a class imported from the forest-data-model library.
-            # 3. I'm currently assuming that since the new_aggregate is written per thinning_method and per time_point, 
-            #  the thinning_output will not be written to twice (otherwise would need to accommodate it for updates)
-    
-    # this structure is currently stored in operation_aggregates separately for each thinning method and for each timing.
     new_aggregate = {'thinning_output': thinning_output}
     return (stand, new_aggregate)

--- a/forestryfunctions/harvest/thinning.py
+++ b/forestryfunctions/harvest/thinning.py
@@ -1,11 +1,12 @@
 from typing import Tuple, Callable
 from forestdatamodel.model import ForestStand
 
+
 def iterative_thinning(
         stand: ForestStand,
         thinning_factor: float,
         thin_predicate: Callable,
-        extra_factor_solver: Callable
+        extra_factor_solver: Callable,
 ) -> Tuple[ForestStand, dict]:
     """ Iteratively decreases the stem count of stand reference trees until stoppin condition is met.
 
@@ -16,18 +17,39 @@ def iterative_thinning(
     :param thinning_factor: Intensity of the thinning on each iteration
     :param thin_predicate: Condition to stop thinning
     :param extra_factor_solver: Gradually increasing proportion of removal
-    :retuns: Thinned stand and number of removed stems
+    :param time_point: Time point of thinning
+    :returns: Thinned stand and number of removed stems per reference tree at the given time point
     """
     n = len(stand.reference_trees)
     c = thinning_factor
-    stems_removed = 0.0
+    # stems_removed = 0.0
+    thinning_output = {}
     while thin_predicate(stand):
         # cut until lower bound reached
         for i, rt in enumerate(stand.reference_trees):
             thin_factor = c + extra_factor_solver(i, n, c)
             thin_factor = 1.0 if thin_factor > 1.0 else thin_factor
             new_stems_per_ha = rt.stems_per_ha * thin_factor
-            stems_removed += rt.stems_per_ha - new_stems_per_ha
+            # stems_removed += rt.stems_per_ha - new_stems_per_ha
+            stems_removed_per_ha = rt.stems_per_ha - new_stems_per_ha
             rt.stems_per_ha = new_stems_per_ha
-    new_aggregate = { 'stems_removed': stems_removed }
+
+            # collect stems_removed and tree-level variables required by the cross cut function per reference tree to dict.
+            # this structure is currently stored in operation_aggregates separately for each thinning method and for each timing.
+            
+            #NOTE: some considerations to address before merging
+            # 1. Will collecting this data on per-reference_tree basis be a memory issue when running the sim with a full dataset?
+            # 2. I'd also rather make thinning_output a class imported from the forest-data-model library.
+            # 3. I'm currently assuming that since the new_aggregate is written per thinning_method and per time_point, 
+            #  the thinning_output will not be written to twice (otherwise would need to accommodate it for updates)
+            thinning_output[rt.identifier] = {
+                'stems_removed_per_ha': stems_removed_per_ha,
+                'species': rt.species,
+                'breast_height_diameter': rt.breast_height_diameter,
+                'height': rt.height,
+                'stems_per_ha': rt.stems_per_ha,
+                'stand_area': stand.area,
+            }
+            
+    new_aggregate = {'thinning_output': thinning_output}
     return (stand, new_aggregate)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="forestryfunctions",
     description="Forestry functions for manipulating state of forest-data-model instances",
-    version="0.1.0",
+    version="0.2.0",
     packages=setuptools.find_namespace_packages(include=['forestryfunctions*']),
     dependency_links=['https://github.com/menu-hanke/forest-data-model@0.3.1#egg=forestdatamodel']
 )

--- a/tests/thinning_test.py
+++ b/tests/thinning_test.py
@@ -26,6 +26,8 @@ class ThinningTest(unittest.TestCase):
         self.assertEqual(171.747, round(result_stand.reference_trees[0].stems_per_ha, 3))
         self.assertEqual(172.606, round(result_stand.reference_trees[1].stems_per_ha, 3))
         self.assertEqual(173.464, round(result_stand.reference_trees[2].stems_per_ha, 3))
-        # self.assertEqual(85.183, round(result_aggregates['stems_removed'], 3))
-        self.assertEqual(5.312, round(result_aggregates['thinning_output']["tree-1"]["stems_removed_per_ha"], 3))
+        self.assertEqual(28.253, round(result_aggregates['thinning_output']["tree-1"]["stems_removed_per_ha"], 3))
+        self.assertEqual(28.394, round(result_aggregates['thinning_output']["tree-2"]["stems_removed_per_ha"], 3))
+        self.assertEqual(28.536, round(result_aggregates['thinning_output']["tree-3"]["stems_removed_per_ha"], 3))
+
 

--- a/tests/thinning_test.py
+++ b/tests/thinning_test.py
@@ -10,10 +10,11 @@ class ThinningTest(unittest.TestCase):
         species = [ TreeSpecies(i) for i in [1,2,3] ]
         diameters = [ 20.0 + i for i in range(0, 3) ]
         stems = [ 200.0 + i for i in range(0, 3) ]
+        ids = ["tree-1", "tree-2", "tree-3"]
         fixture = ForestStand()
         fixture.reference_trees = [
-            ReferenceTree(species=spe, breast_height_diameter=d, stems_per_ha=f)
-            for spe, d, f in zip(species, diameters, stems)
+            ReferenceTree(species=spe, breast_height_diameter=d, stems_per_ha=f, identifier=id)
+            for spe, d, f, id in zip(species, diameters, stems, ids)
         ]
 
         thinning_factor = 0.97
@@ -25,4 +26,6 @@ class ThinningTest(unittest.TestCase):
         self.assertEqual(171.747, round(result_stand.reference_trees[0].stems_per_ha, 3))
         self.assertEqual(172.606, round(result_stand.reference_trees[1].stems_per_ha, 3))
         self.assertEqual(173.464, round(result_stand.reference_trees[2].stems_per_ha, 3))
-        self.assertEqual(85.183, round(result_aggregates['stems_removed'], 3))
+        # self.assertEqual(85.183, round(result_aggregates['stems_removed'], 3))
+        self.assertEqual(5.312, round(result_aggregates['thinning_output']["tree-1"]["stems_removed_per_ha"], 3))
+


### PR DESCRIPTION
[PR 125](https://github.com/menu-hanke/sim-workbench/pull/125) in sim-wb expects the output in the format defined here