### PR TITLE
Fix grow_acta group by species

### DIFF
--- a/forestryfunctions/naturalprocess/grow_acta.py
+++ b/forestryfunctions/naturalprocess/grow_acta.py
@@ -63,7 +63,9 @@ def grow_diameter_and_height(matures_trees: List[ReferenceTree], years: int = 5)
     """ Diameter and height growth for trees with height > 1.3 meters. Based on Acta Forestalia Fennica 163. """
     basal_area_total = futil.calculate_attribute_sum(matures_trees, futil.calculate_basal_area)
     dominant_height = futil.solve_dominant_height(matures_trees)
-    tree_groups = itertools.groupby(matures_trees, key=lambda rt: rt.species)
+    tree_groups = itertools.groupby(
+        sorted(matures_trees, key=lambda rt: rt.species),
+        key=lambda rt: rt.species)
     # Calculate growth for each tree species
     for _, tree_group in tree_groups:
         trees = list(tree_group)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="forestryfunctions",
     description="Forestry functions for manipulating state of forest-data-model instances",
-    version="0.1.0",
+    version="0.1.2",
     packages=setuptools.find_namespace_packages(include=['forestryfunctions*']),
     dependency_links=['https://github.com/menu-hanke/forest-data-model@0.3.1#egg=forestdatamodel']
 )

--- a/tests/grow_acta_test.py
+++ b/tests/grow_acta_test.py
@@ -67,12 +67,12 @@ class GrowActaTest(unittest.TestCase):
             for d, h, f, spe, age in zip(diameters, heights, stems, species, ages)
         ]
         result = grow_acta.grow_diameter_and_height(reference_trees)
-        self.assertEqual(21.6013, round(result[0].breast_height_diameter, 4))
-        self.assertEqual(24.2168, round(result[0].height, 4))
-        self.assertEqual(22.9472, round(result[1].breast_height_diameter, 4))
-        self.assertEqual(24.5899, round(result[1].height, 4))
-        self.assertEqual(23.6670, round(result[2].breast_height_diameter, 4))
-        self.assertEqual(26.2243, round(result[2].height, 4))
+        self.assertEqual(21.5922, round(result[0].breast_height_diameter, 4))
+        self.assertEqual(24.2359, round(result[0].height, 4))
+        self.assertEqual(22.9209, round(result[1].breast_height_diameter, 4))
+        self.assertEqual(24.443, round(result[1].height, 4))
+        self.assertEqual(23.6697, round(result[2].breast_height_diameter, 4))
+        self.assertEqual(26.2199, round(result[2].height, 4))
 
     def test_grow_sapling(self):
         diameters = [1.0, 1.1, 1.2, None]


### PR DESCRIPTION
Just a bug fix. No issue for this.

itertools.groupby does not group in the same species category unless the reference trees are in a sorted order by tree species.

Unordered grouping made multiple groups of reference trees that had same tree species as key. This caused a ZeroDivisionError in `calculate_basal_area_weighted_attribute_sum` function.
For correctly handling the ZeroDivisionError a issues was made #7 
